### PR TITLE
fix: nombre de archivo del post en inglés y YAML del título

### DIFF
--- a/_posts/2026-08-01-reclaim-var-oled-oracle-cloud.md
+++ b/_posts/2026-08-01-reclaim-var-oled-oracle-cloud.md
@@ -1,5 +1,5 @@
 ---
-title: Recuperar espacio en un VPS de Oracle Cloud: logrotate y reclaim de /var/oled
+title: "Recuperar espacio en un VPS de Oracle Cloud: logrotate y reclaim de /var/oled"
 authors: [meyer]
 date: 2026-08-01 18:45:00 -0500
 categories: [Tutorial, Linux]


### PR DESCRIPTION
Renombra el post a `_posts/2026-08-01-reclaim-var-oled-oracle-cloud.md` (nombre en inglés) y corrige el error de YAML del front matter: el título con `: ` sin comillas rompía el parseo (`mapping values are not allowed in this context`), por lo que no se mostraba el título en el blog.